### PR TITLE
index grammar fix

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -2,7 +2,7 @@ Welcome to the Tox Developer site!
 ===========================================
 Tox is a secure and distributed Skype replacement.
 
-At its heart it's a client dealing with our core library communicating on our own protocol. All communications are encrypted using the peer audited ``NaCl`` cypto library and this encryption can not be turned off.
+At its heart it's a client dealing with our core library communicating on our own protocol. All communications are encrypted using the peer audited ``NaCl`` crypto library and this encryption can not be turned off.
 
 Tox is powered by a distributed network which uses P2P connections for chats between people, unlike other Skype replacements no federated servers, centralized servers, or supernodes are used.
 


### PR DESCRIPTION
It said cypto instead of crypto. :D
